### PR TITLE
Stale league nav

### DIFF
--- a/src/components/league/league.js
+++ b/src/components/league/league.js
@@ -21,8 +21,6 @@ function League(props) {
 
   const dispatch = useLeagueDispatch();
 
-  console.log(props);
-
   useEffect(() => {
     
     setLeagueContext();
@@ -37,7 +35,6 @@ function League(props) {
    * @function setLeagueContext
    */
   const setLeagueContext = () => {
-    console.log('league component dispatching context updates');
 
     if (props.location.state.tournamentId) {
       dispatch({ type: 'update', key: 'tournamentId', value: props.location.state.tournamentId });

--- a/src/context/leagueContext.js
+++ b/src/context/leagueContext.js
@@ -54,7 +54,7 @@ function clearLeagueStorage() {
 
 function LeagueProvider({children}) {
   // initialize state from localstorage
-  const [state, dispatch] = useReducer(leagueReducer, getLeagueStorage());
+  const [state, dispatch] = useReducer(leagueReducer, {});
 
   return (
     <LeagueStateContext.Provider value={state}>


### PR DESCRIPTION
fixes league component loading the incorrect league data, which was caused by initializing leagueContext from localstorage.